### PR TITLE
Fix sample cloning and update repository name in workflows

### DIFF
--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -22,7 +22,7 @@ jobs:
     - run: npm run webpack:build
     - name: deploy to web-abap2ui5-samples
       uses: peaceiris/actions-gh-pages@v4
-      if: github.ref == 'refs/heads/main' && github.repository == 'abap2UI5/abap2UI5-web'
+      if: github.ref == 'refs/heads/main' && github.repository == 'abap2UI5/web-abap2UI5'
       with:
         deploy_key: ${{ secrets.DEPLOY_WEB }}
         external_repository: abap2UI5/web-abap2ui5-samples

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "description": "Developing UI5 Apps purely in ABAP.",
   "scripts": {
     "clone1": "rm -rf abap2UI5 && git clone --depth=1 https://github.com/abap2UI5/abap2UI5 && cp -r abap2UI5/src src",
-    "clone2": "rm -rf abap2UI5-samples && git clone --depth=1 https://github.com/abap2UI5/samples abap2UI5-samples && mkdir -p src/samples && cp abap2UI5-samples/src/*.* src/samples",
+    "clone2": "rm -rf abap2UI5-samples && git clone --depth=1 --branch cloud https://github.com/abap2UI5/samples abap2UI5-samples && mkdir -p src/samples && cp -r abap2UI5-samples/src/. src/samples",
     "clone": "rm -rf src && npm run clone1 && npm run clone2",
     "init_abap2ui5": "rm -rf src && rm -rf abap2UI5 &&  mkdir src && git clone --depth=1 https://github.com/abap2UI5/abap2UI5.git && cp -r abap2UI5/src/* src/",
-    "init_samples": "rm -rf abap2UI5-samples && git clone --depth=1 https://github.com/abap2UI5/samples abap2UI5-samples && mkdir -p src/samples && cp abap2UI5-samples/src/*.* src/samples",
+    "init_samples": "rm -rf abap2UI5-samples && git clone --depth=1 --branch cloud https://github.com/abap2UI5/samples abap2UI5-samples && mkdir -p src/samples && cp -r abap2UI5-samples/src/. src/samples",
     "init": "npm run init_abap2ui5 && npm run init_samples",
     "syfixes": "find . -type f -name '*.abap' -exec sed -i -e 's/ RAISE EXCEPTION TYPE cx_sy_itab_line_not_found/ ASSERT 1 = 0/g' {} + ",
     "downport": "rm -rf downport && cp -r src downport && abaplint --fix ./ci/abaplint-downport.jsonc && npm run syfixes",

--- a/workflows/build_web.yaml
+++ b/workflows/build_web.yaml
@@ -22,7 +22,7 @@ jobs:
     - run: npm run webpack:build
     - name: deploy to web-abap2ui5-samples
       uses: peaceiris/actions-gh-pages@v4
-      if: github.ref == 'refs/heads/main' && github.repository == 'abap2UI5/abap2UI5-web'
+      if: github.ref == 'refs/heads/main' && github.repository == 'abap2UI5/web-abap2UI5'
       with:
         deploy_key: ${{ secrets.DEPLOY_WEB }}
         external_repository: abap2UI5/web-abap2ui5-samples


### PR DESCRIPTION
## Summary
This PR fixes the sample cloning process and corrects the repository name reference in the GitHub Actions workflows.

## Key Changes
- **Updated `clone2` and `init_samples` scripts**: 
  - Added `--branch cloud` flag to clone from the `cloud` branch of the samples repository
  - Changed `cp abap2UI5-samples/src/*.*` to `cp -r abap2UI5-samples/src/. src/samples` to properly copy directory structures recursively instead of just files
  
- **Fixed repository name in GitHub Actions workflows**:
  - Updated the condition in `.github/workflows/build_web.yaml` and `workflows/build_web.yaml` from `abap2UI5/abap2UI5-web` to `abap2UI5/web-abap2UI5` to match the actual repository name

## Implementation Details
The sample cloning changes ensure that:
1. The correct branch (`cloud`) is used when cloning samples
2. Directory structures within the samples are preserved during the copy operation, not just top-level files
3. The deployment workflow correctly identifies the repository for conditional execution

https://claude.ai/code/session_01X98eNQTpsUgck9e8xggdQe