### PR TITLE
Update deployment repository name to web-abap2UI5-build

### DIFF
--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -20,12 +20,12 @@ jobs:
     - run: npm run clone
     - run: npm run build && node output/index.mjs
     - run: npm run webpack:build
-    - name: deploy to web-abap2ui5-samples
+    - name: deploy to web-abap2UI5-build
       uses: peaceiris/actions-gh-pages@v4
       if: github.ref == 'refs/heads/main' && github.repository == 'abap2UI5/web-abap2UI5'
       with:
         deploy_key: ${{ secrets.DEPLOY_WEB }}
-        external_repository: abap2UI5/web-abap2ui5-samples
+        external_repository: abap2UI5/web-abap2UI5-build
         user_name: 'github-actions[bot]'
         user_email: 'github-actions[bot]@users.noreply.github.com'
         publish_branch: main

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## abap2UI5-web
+## web-abap2UI5
 
 ### Functionality
 * Downporting with [abaplint](https://abaplint.org/)

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ npm run webpack:build
 
 ### Demo
 Backend Running in Browser
-[https://abap2ui5.github.io/web-abap2ui5-samples/](https://abap2ui5.github.io/web-abap2ui5-samples/)
+[https://abap2ui5.github.io/web-abap2UI5-build/](https://abap2ui5.github.io/web-abap2UI5-build/)
 
 ### CI
-The `build_web` workflow runs daily: it clones [abap2UI5](https://github.com/abap2UI5/abap2UI5) and the top-level apps of [samples](https://github.com/abap2UI5/samples), runs downport, transpile, unit tests and the webpack build, and deploys the result to [web-abap2ui5-samples](https://github.com/abap2UI5/web-abap2ui5-samples) (GitHub Pages). Note: GitHub disables scheduled workflows after 60 days without repository activity — re-enable it under Actions if the demo stops updating.
+The `build_web` workflow runs daily: it clones [abap2UI5](https://github.com/abap2UI5/abap2UI5) and the top-level apps of [samples](https://github.com/abap2UI5/samples), runs downport, transpile, unit tests and the webpack build, and deploys the result to [web-abap2UI5-build](https://github.com/abap2UI5/web-abap2UI5-build) (GitHub Pages). Note: GitHub disables scheduled workflows after 60 days without repository activity — re-enable it under Actions if the demo stops updating.
 
 `@abaplint/cli` is pinned to the version used by abap2UI5 itself, since the downport result must pass the same syntax check.
 

--- a/workflows/build_web.yaml
+++ b/workflows/build_web.yaml
@@ -20,12 +20,12 @@ jobs:
     - run: npm run clone
     - run: npm run build && node output/index.mjs
     - run: npm run webpack:build
-    - name: deploy to web-abap2ui5-samples
+    - name: deploy to web-abap2UI5-build
       uses: peaceiris/actions-gh-pages@v4
       if: github.ref == 'refs/heads/main' && github.repository == 'abap2UI5/web-abap2UI5'
       with:
         deploy_key: ${{ secrets.DEPLOY_WEB }}
-        external_repository: abap2UI5/web-abap2ui5-samples
+        external_repository: abap2UI5/web-abap2UI5-build
         user_name: 'github-actions[bot]'
         user_email: 'github-actions[bot]@users.noreply.github.com'
         publish_branch: main


### PR DESCRIPTION
## Summary
This PR updates the GitHub Actions workflow and documentation to reflect a rename of the deployment target repository from `web-abap2ui5-samples` to `web-abap2UI5-build`.

## Key Changes
- Updated the `build_web` workflow deployment step to target the new `web-abap2UI5-build` repository
- Updated the deployment step name from "deploy to web-abap2ui5-samples" to "deploy to web-abap2UI5-build"
- Updated the demo URL in README.md to point to the new repository's GitHub Pages site
- Updated the CI documentation in README.md to reference the new repository name

## Details
The changes ensure that the automated daily build workflow correctly deploys build artifacts to the renamed repository while maintaining the same deployment mechanism and GitHub Pages hosting setup.

https://claude.ai/code/session_01MFoHdquFyQEfsWPJoMHxec