### PR TITLE
Update transpile config for Z2UI5_CL_UTIL_EXT test exclusion

### DIFF
--- a/ci/abap_transpile.json
+++ b/ci/abap_transpile.json
@@ -29,7 +29,7 @@
       {"object": "Z2UI5_CL_AJSON", "class": "ltcl_parser_test", "method": "unicode_characters", "note": "CL_ABAP_CONV_IN_CE=>uccpi dynamic call not supported in NodeJS runtime"},
       {"object": "Z2UI5_CL_AJSON", "class": "ltcl_writer_test", "method": "set_timestampl", "note": "NodeJS timestamp precision is milliseconds, ABAP expects microseconds"},
       {"object": "Z2UI5_CL_AJSON", "class": "ltcl_abap_to_json", "method": "set_value_timestampl", "note": "NodeJS timestamp precision is milliseconds, ABAP expects microseconds"},
-      {"object": "Z2UI5_CL_UTIL", "class": "ltcl_unit_test_conversion", "method": "test_zip_unpack", "note": "CL_ABAP_ZIP=>LOAD is not implemented in the open-abap transpiler runtime"}
+      {"object": "Z2UI5_CL_UTIL_EXT", "class": "ltcl_unit_test", "method": "test_zip_unpack", "note": "CL_ABAP_ZIP=>LOAD is not implemented in the open-abap transpiler runtime"}
     ]
   }
 }


### PR DESCRIPTION
## Summary
Updated the ABAP transpile configuration to reflect changes in the test class structure for ZIP utility functionality.

## Changes
- Updated the excluded test reference from `Z2UI5_CL_UTIL` class `ltcl_unit_test_conversion` to `Z2UI5_CL_UTIL_EXT` class `ltcl_unit_test`
- The exclusion remains for the `test_zip_unpack` method due to the same runtime limitation: `CL_ABAP_ZIP=>LOAD` is not implemented in the open-abap transpiler runtime

## Details
This change reflects a refactoring where the ZIP utility test was moved to a different class (`Z2UI5_CL_UTIL_EXT`) and the test class was renamed from `ltcl_unit_test_conversion` to `ltcl_unit_test`. The underlying reason for excluding this test from the NodeJS transpilation remains unchanged.

https://claude.ai/code/session_011CN4e3KhrjDwP2AhN1o9wx