### PR TITLE
Fix module initialization order in browser bundles

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>abap2UI5</title>
+    <link rel="icon" href="data:," />
     <style>
         html, body, body > div, #container, #container-uiarea {
             height: 100%;

--- a/ci/patch_init_order.mjs
+++ b/ci/patch_init_order.mjs
@@ -1,0 +1,34 @@
+// Post-transpile patch: serialize module initialization in output/_init.mjs.
+//
+// The transpiler emits one static `import "./<module>.mjs";` per object. All
+// of these modules use top-level await, which makes them async modules: the
+// ECMAScript spec only guarantees that async sibling modules *start* in
+// order, not that each one *finishes* before the next one starts. Cross-class
+// references made during class_constructor execution (e.g. Z2UI5_CL_UTIL
+// reading CL_ABAP_OBJECTDESCR=>PUBLIC) go through the abap.Classes registry
+// and are invisible to the module graph, so they rely on sibling completion
+// order. Node's scheduler happens to evaluate the modules in a working
+// order, but webpack's async-module runtime does not — in the browser bundle
+// Z2UI5_CL_UTIL's class_constructor runs before CL_ABAP_OBJECTDESCR is
+// registered, which crashes the GitHub page with
+// "Cannot read properties of undefined (reading 'public')".
+//
+// Rewriting the static imports into sequential top-level `await import(...)`
+// calls forces each module (including all of its own top-level awaits) to
+// finish evaluating before the next one starts, in the dependency order the
+// transpiler already emits. This makes the initialization order deterministic
+// in every ESM runtime and bundler.
+import { readFileSync, writeFileSync } from "node:fs";
+
+const file = new URL("../output/_init.mjs", import.meta.url);
+let src = readFileSync(file, "utf8");
+
+const before = src;
+src = src.replace(/^import ("\.\/[^"]+");$/gm, "await import($1);");
+
+if (src === before) {
+  throw new Error("patch_init_order: no static imports found in output/_init.mjs — transpiler output format changed?");
+}
+
+writeFileSync(file, src);
+console.log("patch_init_order: serialized module initialization in output/_init.mjs");

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "downport": "rm -rf downport && cp -r src downport && abaplint --fix ./ci/abaplint-downport.jsonc && npm run syfixes",
     "downport_samples": "rm -rf downport && cp -r src downport && abaplint --fix ./ci/abaplint-downport-samples.jsonc && npm run syfixes",
     "unit": "echo RUNNING && node output/index.mjs",
-    "transpile": "rm -rf output && cp srv/*.abap downport && abap_transpile ./ci/abap_transpile.json",
+    "transpile": "rm -rf output && cp srv/*.abap downport && abap_transpile ./ci/abap_transpile.json && node ci/patch_init_order.mjs",
     "test": "npm run downport && npm run transpile && npm run unit",
     "cleanup": "rm -rf input && rm -rf output",
     "express": "node srv/express.mjs",


### PR DESCRIPTION
## Summary
This PR fixes a critical initialization order bug that causes crashes in webpack-bundled browser environments by ensuring ABAP module initialization happens sequentially rather than concurrently.

## Key Changes
- **Added `ci/patch_init_order.mjs`**: A post-transpile patch script that converts static `import` statements in `output/_init.mjs` into sequential `await import()` calls. This forces each module to complete initialization (including all top-level awaits) before the next one starts, making the initialization order deterministic across all ESM runtimes and bundlers.
- **Updated `package.json`**: Modified the `transpile` npm script to run the patch script after transpilation completes.
- **Updated `app/index.html`**: Added a favicon link to suppress browser 404 requests for missing favicon.

## Implementation Details
The patch addresses a subtle but critical issue: while Node.js's module scheduler happens to evaluate sibling async modules in a working order, webpack's async-module runtime does not. This caused cross-class references made during `class_constructor` execution (which go through the `abap.Classes` registry and are invisible to the module graph) to fail in the browser bundle. For example, `Z2UI5_CL_UTIL`'s class constructor would run before `CL_ABAP_OBJECTDESCR` was registered, causing "Cannot read properties of undefined" errors.

The solution uses a regex-based transformation to rewrite the transpiler's static imports into sequential awaited dynamic imports, ensuring deterministic initialization order in every ESM runtime and bundler.

https://claude.ai/code/session_01Rv4Th3u7N7pnfR8wW9kMtG