### PR TITLE
fix: bundle all transpiled modules into a single chunk

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,5 +65,11 @@ module.exports = ({mode} = {mode: "development"}) => ({
       process: 'process/browser',
       Buffer: ['buffer', 'Buffer'],
     }),
+    // The transpiled output loads every module via top-level `await import()`
+    // (see ci/patch_init_order.mjs), which webpack would otherwise split into
+    // one tiny async chunk per ABAP object — 1700+ files and ~1000 requests
+    // on GitHub Pages. Merging everything into a single chunk keeps the
+    // deterministic initialization order but ships one bundle.
+    new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 }),
   ],
 });


### PR DESCRIPTION
The serialized top-level await imports from ci/patch_init_order.mjs are dynamic imports from webpack's point of view, so it emitted one tiny async chunk per ABAP object — 1700+ files in web-abap2UI5-build and ~1000 requests on page load, which made the GitHub page extremely slow (and GitHub truncates the directory listing at 1000 files).

Limit webpack to a single chunk so the whole transpiled backend ships as one app.bundle.js. The deterministic initialization order is unchanged; the build folder shrinks to 6 files and the page loads with 3 requests instead of ~1000.


Claude-Session: https://claude.ai/code/session_01Rv4Th3u7N7pnfR8wW9kMtG