### PR TITLE
fix: exclude obsolete src/99 from the build, fix broken downport anchor

### DIFF
--- a/ci/abap_transpile.json
+++ b/ci/abap_transpile.json
@@ -28,8 +28,7 @@
       {"object": "Z2UI5_CL_AJSON", "class": "ltcl_parser_test", "method": "parse_error", "note": "NodeJS 20 does not set position of parsing error"},
       {"object": "Z2UI5_CL_AJSON", "class": "ltcl_parser_test", "method": "unicode_characters", "note": "CL_ABAP_CONV_IN_CE=>uccpi dynamic call not supported in NodeJS runtime"},
       {"object": "Z2UI5_CL_AJSON", "class": "ltcl_writer_test", "method": "set_timestampl", "note": "NodeJS timestamp precision is milliseconds, ABAP expects microseconds"},
-      {"object": "Z2UI5_CL_AJSON", "class": "ltcl_abap_to_json", "method": "set_value_timestampl", "note": "NodeJS timestamp precision is milliseconds, ABAP expects microseconds"},
-      {"object": "Z2UI5_CL_UTIL_EXT", "class": "ltcl_unit_test", "method": "test_zip_unpack", "note": "CL_ABAP_ZIP=>LOAD is not implemented in the open-abap transpiler runtime"}
+      {"object": "Z2UI5_CL_AJSON", "class": "ltcl_abap_to_json", "method": "set_value_timestampl", "note": "NodeJS timestamp precision is milliseconds, ABAP expects microseconds"}
     ]
   }
 }

--- a/ci/patch_diss_oref.mjs
+++ b/ci/patch_diss_oref.mjs
@@ -46,7 +46,7 @@ if (!file) {
 
 let src = readFileSync(file, "utf8");
 
-const anchor = "    DATA(lr_ref) = z2ui5_cl_util=>unassign_object( lr_val ).";
+const anchor = "    DATA(lr_ref) = z2ui5_cl_abap2ui5_context=>unassign_object( lr_val ).";
 const guard = `
     " Patch for the transpiled all-in-browser build (ci/patch_diss_oref.mjs):
     " never dissolve into abap2UI5 framework objects. The open-abap runtime

--- a/ci/patch_init_order.mjs
+++ b/ci/patch_init_order.mjs
@@ -4,14 +4,15 @@
 // of these modules use top-level await, which makes them async modules: the
 // ECMAScript spec only guarantees that async sibling modules *start* in
 // order, not that each one *finishes* before the next one starts. Cross-class
-// references made during class_constructor execution (e.g. Z2UI5_CL_UTIL
-// reading CL_ABAP_OBJECTDESCR=>PUBLIC) go through the abap.Classes registry
+// references made during class_constructor execution (e.g.
+// Z2UI5_CL_ABAP2UI5_CONTEXT reading CL_ABAP_CHAR_UTILITIES=>NEWLINE) go
+// through the abap.Classes registry
 // and are invisible to the module graph, so they rely on sibling completion
 // order. Node's scheduler happens to evaluate the modules in a working
 // order, but webpack's async-module runtime does not — in the browser bundle
-// Z2UI5_CL_UTIL's class_constructor runs before CL_ABAP_OBJECTDESCR is
-// registered, which crashes the GitHub page with
-// "Cannot read properties of undefined (reading 'public')".
+// Z2UI5_CL_ABAP2UI5_CONTEXT's class_constructor runs before its dependencies
+// (e.g. CL_ABAP_CHAR_UTILITIES) are registered, which crashes the GitHub page
+// with "Cannot read properties of undefined".
 //
 // Rewriting the static imports into sequential top-level `await import(...)`
 // calls forces each module (including all of its own top-level awaits) to

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "version": "1.0.0",
   "description": "Developing UI5 Apps purely in ABAP.",
   "scripts": {
-    "clone1": "rm -rf abap2UI5 && git clone --depth=1 https://github.com/abap2UI5/abap2UI5 && cp -r abap2UI5/src src",
+    "clone1": "rm -rf abap2UI5 && git clone --depth=1 https://github.com/abap2UI5/abap2UI5 && cp -r abap2UI5/src src && rm -rf src/99",
     "clone2": "rm -rf abap2UI5-samples && git clone --depth=1 --branch cloud https://github.com/abap2UI5/samples abap2UI5-samples && mkdir -p src/samples && cp -r abap2UI5-samples/src/. src/samples",
     "clone": "rm -rf src && npm run clone1 && npm run clone2",
-    "init_abap2ui5": "rm -rf src && rm -rf abap2UI5 &&  mkdir src && git clone --depth=1 https://github.com/abap2UI5/abap2UI5.git && cp -r abap2UI5/src/* src/",
+    "init_abap2ui5": "rm -rf src && rm -rf abap2UI5 &&  mkdir src && git clone --depth=1 https://github.com/abap2UI5/abap2UI5.git && cp -r abap2UI5/src/* src/ && rm -rf src/99",
     "init_samples": "rm -rf abap2UI5-samples && git clone --depth=1 --branch cloud https://github.com/abap2UI5/samples abap2UI5-samples && mkdir -p src/samples && cp -r abap2UI5-samples/src/. src/samples",
     "init": "npm run init_abap2ui5 && npm run init_samples",
     "syfixes": "find . -type f -name '*.abap' -exec sed -i -e 's/ RAISE EXCEPTION TYPE cx_sy_itab_line_not_found/ ASSERT 1 = 0/g' {} + ",


### PR DESCRIPTION
## Why

abap2UI5 moved the retired `z2ui5_cl_util*` classes into the new obsolete package `src/99` and switched the framework core to `z2ui5_cl_abap2ui5_context` (abap2UI5/abap2UI5#2402, abap2UI5/abap2UI5#2406). This broke every `build_web` run since:

- the renamed `z2ui5_cl_util_ext` test classes no longer match the transpiler skip entry, so the zip roundtrip test runs in the Node runtime and dies with `CONVT_NO_NUMBER` (`CL_ABAP_ZIP=>LOAD` is not implemented there)
- `ci/patch_diss_oref.mjs` anchors on the old `z2ui5_cl_util=>unassign_object` call in `z2ui5_cl_core_srv_model` and would abort the downport with "anchor line not found" even with the skip fixed

## What

- **`package.json`**: `clone1` / `init_abap2ui5` drop `src/99` right after copying — the obsolete package (and its tests) is no longer transpiled at all, so future changes to it can't break this build
- **`ci/abap_transpile.json`**: remove the now-dead `Z2UI5_CL_UTIL_EXT` skip entry
- **`ci/patch_diss_oref.mjs`**: anchor on the new `z2ui5_cl_abap2ui5_context=>unassign_object` call
- **`ci/patch_init_order.mjs`**: comments only — the explanatory example referenced the no-longer-built `Z2UI5_CL_UTIL`

## Verification

Full pipeline run locally against current upstream `main`: `npm ci` → `clone` (no `src/99` in the result, no remaining references to the util classes in the copied sources incl. samples) → `downport` (abaplint 0 issues, patch applies) → `transpile` (878 objects) → `unit` (exit 0) → `webpack:build` (compiles successfully).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KXDMmtXDGJTPXXaCuPPvQ

---
_Generated by [Claude Code](https://claude.ai/code/session_019KXDMmtXDGJTPXXaCuPPvQ)_