### PR TITLE
Add XML view class files to clone and init scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "version": "1.0.0",
   "description": "Developing UI5 Apps purely in ABAP.",
   "scripts": {
-    "clone1": "rm -rf abap2UI5 && git clone --depth=1 https://github.com/abap2UI5/abap2UI5 && cp -r abap2UI5/src src && cp src/99/02/z2ui5_cl_pop_*.clas.abap src/99/02/z2ui5_cl_pop_*.clas.xml src/02/ && rm -rf src/99",
+    "clone1": "rm -rf abap2UI5 && git clone --depth=1 https://github.com/abap2UI5/abap2UI5 && cp -r abap2UI5/src src && cp src/99/02/z2ui5_cl_pop_*.clas.abap src/99/02/z2ui5_cl_pop_*.clas.xml src/02/ && ( cp src/99/z2ui5_cl_xml_view*.clas.* src/02/ 2>/dev/null || true ) && rm -rf src/99",
     "clone2": "rm -rf abap2UI5-samples && git clone --depth=1 --branch cloud https://github.com/abap2UI5/samples abap2UI5-samples && mkdir -p src/samples && cp -r abap2UI5-samples/src/. src/samples",
     "clone": "rm -rf src && npm run clone1 && npm run clone2",
-    "init_abap2ui5": "rm -rf src && rm -rf abap2UI5 &&  mkdir src && git clone --depth=1 https://github.com/abap2UI5/abap2UI5.git && cp -r abap2UI5/src/* src/ && cp src/99/02/z2ui5_cl_pop_*.clas.abap src/99/02/z2ui5_cl_pop_*.clas.xml src/02/ && rm -rf src/99",
+    "init_abap2ui5": "rm -rf src && rm -rf abap2UI5 &&  mkdir src && git clone --depth=1 https://github.com/abap2UI5/abap2UI5.git && cp -r abap2UI5/src/* src/ && cp src/99/02/z2ui5_cl_pop_*.clas.abap src/99/02/z2ui5_cl_pop_*.clas.xml src/02/ && ( cp src/99/z2ui5_cl_xml_view*.clas.* src/02/ 2>/dev/null || true ) && rm -rf src/99",
     "init_samples": "rm -rf abap2UI5-samples && git clone --depth=1 --branch cloud https://github.com/abap2UI5/samples abap2UI5-samples && mkdir -p src/samples && cp -r abap2UI5-samples/src/. src/samples",
     "init": "npm run init_abap2ui5 && npm run init_samples",
     "syfixes": "find . -type f -name '*.abap' -exec sed -i -e 's/ RAISE EXCEPTION TYPE cx_sy_itab_line_not_found/ ASSERT 1 = 0/g' {} + ",


### PR DESCRIPTION
## Summary
Updated the `clone1` and `init_abap2ui5` npm scripts to include copying of XML view class files (`z2ui5_cl_xml_view*.clas.*`) from the source directory during initialization.

## Changes
- Modified `clone1` script to copy `z2ui5_cl_xml_view*.clas.*` files from `src/99/` to `src/02/` with error suppression
- Modified `init_abap2ui5` script with the same XML view class file copying logic
- Both scripts now use `( cp ... 2>/dev/null || true )` pattern to gracefully handle cases where these files may not exist

## Details
The changes ensure that XML view class files are properly included in the source directory structure during both clone and initialization operations. The error suppression allows the scripts to continue successfully even if these files are not present in the source repository, making the scripts more robust and flexible.

https://claude.ai/code/session_01AnPekaAD58RcJG8obUdwoK