### PR TITLE
Slim the Pages deploy, browser-smoke it before deploying, fix package metadata

### DIFF
--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -21,7 +21,7 @@ env:
 jobs:
   build_web:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20 # browser smoke needs the Chromium download on top of the build
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -57,6 +57,16 @@ jobs:
       if: steps.upstream.outputs.changed == 'true'
     - run: npm run webpack:build
       if: steps.upstream.outputs.changed == 'true'
+    # Browser smoke against the freshly built site (tests/web.spec.js via the
+    # chromium-web project: backend boots in the browser, UI5 loads, the first
+    # roundtrip answers). A blank page must never reach the deploy step —
+    # before this gate the site deployed completely untested.
+    - name: Install Playwright Chromium
+      if: steps.upstream.outputs.changed == 'true'
+      run: npx playwright install --with-deps chromium
+    - name: Smoke test the webpack build in a real browser
+      if: steps.upstream.outputs.changed == 'true'
+      run: npx playwright test --project=chromium-web
     - name: Write build stamp
       if: steps.upstream.outputs.changed == 'true'
       run: printf '%s' "${{ steps.upstream.outputs.stamp }}" > build/build-stamp.txt

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "abap2ui5",
+  "name": "web-abap2ui5",
   "private": true,
   "version": "1.0.0",
-  "description": "Developing UI5 Apps purely in ABAP.",
+  "description": "abap2UI5 running fully in the browser - downported, transpiled to JS and bundled for GitHub Pages.",
   "scripts": {
     "clone1": "rm -rf abap2UI5 && git clone --depth=1 https://github.com/abap2UI5/abap2UI5 && cp -r abap2UI5/src src && cp src/99/02/z2ui5_cl_pop_*.clas.abap src/99/02/z2ui5_cl_pop_*.clas.xml src/02/ && ( cp src/99/z2ui5_cl_xml_view*.clas.* src/02/ 2>/dev/null || true ) && rm -rf src/99",
     "clone2": "rm -rf abap2UI5-samples && git clone --depth=1 --branch cloud https://github.com/abap2UI5/samples abap2UI5-samples && mkdir -p src/samples && cp -r abap2UI5-samples/src/. src/samples",
@@ -27,13 +27,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/abap2UI5/abap2UI5.git"
+    "url": "git+https://github.com/abap2UI5/web-abap2UI5.git"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/abap2UI5/abap2UI5/issues"
+    "url": "https://github.com/abap2UI5/web-abap2UI5/issues"
   },
-  "homepage": "https://github.com/abap2UI5/abap2UI5#readme",
+  "homepage": "https://github.com/abap2UI5/web-abap2UI5#readme",
   "devDependencies": {
     "@abaplint/cli": "2.119.66",
     "@abaplint/database-sqlite": "^2.13.40",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,12 +5,16 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 const CopyPlugin = require("copy-webpack-plugin");
 const webpack = require("webpack");
 
-module.exports = ({mode} = {mode: "development"}) => ({
+module.exports = (env = {mode: "development"}) => ({
   entry: {
     "app": "./app/web.mjs",
   },
-  mode,
-  devtool: "nosources-source-map",
+  mode: env.mode,
+  // The source map alone adds ~2 MB to every GitHub Pages deploy, so it is
+  // opt-in for builds (WEB_SOURCEMAP=1) and always on for the dev server.
+  devtool: env.WEBPACK_SERVE || process.env.WEB_SOURCEMAP
+    ? "nosources-source-map"
+    : false,
   experiments: {
     topLevelAwait: true
   },
@@ -65,12 +69,11 @@ module.exports = ({mode} = {mode: "development"}) => ({
     new CopyPlugin({
       patterns: [
         { from: './node_modules/sql.js/dist/sql-wasm.wasm', to: "./" },
-        { from: './node_modules/sql.js/dist/sql-wasm-debug.wasm', to: "./" },
-        { from: './node_modules/sql.js/dist/sql-wasm-debug.js', to: "./" },
         // sql.js >= 1.13 ships a dedicated browser build; the browser entry
         // of @abaplint/database-sqlite fetches sql-wasm-browser.wasm.
+        // The -debug variants of both wasm files (~740 KB each) are never
+        // referenced by the bundle and are not copied into the deploy.
         { from: './node_modules/sql.js/dist/sql-wasm-browser.wasm', to: "./" },
-        { from: './node_modules/sql.js/dist/sql-wasm-browser-debug.wasm', to: "./" },
         // The z2ui5 frontend manifest includes css/style.css; without the
         // file every boot of the GitHub Pages demo logs a 404.
         { from: './app/css/style.css', to: "./css/style.css" },


### PR DESCRIPTION
## Summary

Three hygiene fixes for the browser build:

- **Stop shipping debug artifacts** (~3.4 MB per deploy): the deployed site carried `sql-wasm-debug.wasm`, `sql-wasm-browser-debug.wasm` (~740 KB each), `sql-wasm-debug.js` and the 1.9 MB `app.bundle.js.map`, none of which the bundle references (verified against the deployed `app.bundle.js` — only `sql-wasm.wasm` and `sql-wasm-browser.wasm` are fetched). The source map is now opt-in via `WEB_SOURCEMAP=1`, and the webpack dev server keeps it automatically (`WEBPACK_SERVE`), following the builder-cap2UI5-web convention.
- **Browser-smoke before deploy**: `tests/web.spec.js` and the `chromium-web` Playwright project existed but were never run in CI — the site deployed untested. `build_web.yaml` now runs them between `webpack:build` and the deploy step so a blank page can never reach GitHub Pages (timeout raised to 20 min for the Chromium download).
- **Package metadata**: `name`/`description`/`repository`/`bugs`/`homepage` carried over from the framework repo (abap2UI5/abap2UI5) — they now point at web-abap2UI5.

## Test

Verified locally with the full pipeline (clone, downport, transpile, webpack:build): compiles successfully, `build/` contains only `app.bundle.js`, `index.html`, `css/` and the two production wasm files. The CI smoke gate itself runs on this PR's workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NA4sHtsK85U1f6YKxP7YW