### PR TITLE
Add NodeJS runtime exclusion for tab ref generation test

### DIFF
--- a/ci/abap_transpile.json
+++ b/ci/abap_transpile.json
@@ -28,7 +28,8 @@
       {"object": "Z2UI5_CL_AJSON", "class": "ltcl_parser_test", "method": "parse_error", "note": "NodeJS 20 does not set position of parsing error"},
       {"object": "Z2UI5_CL_AJSON", "class": "ltcl_parser_test", "method": "unicode_characters", "note": "CL_ABAP_CONV_IN_CE=>uccpi dynamic call not supported in NodeJS runtime"},
       {"object": "Z2UI5_CL_AJSON", "class": "ltcl_writer_test", "method": "set_timestampl", "note": "NodeJS timestamp precision is milliseconds, ABAP expects microseconds"},
-      {"object": "Z2UI5_CL_AJSON", "class": "ltcl_abap_to_json", "method": "set_value_timestampl", "note": "NodeJS timestamp precision is milliseconds, ABAP expects microseconds"}
+      {"object": "Z2UI5_CL_AJSON", "class": "ltcl_abap_to_json", "method": "set_value_timestampl", "note": "NodeJS timestamp precision is milliseconds, ABAP expects microseconds"},
+      {"object": "Z2UI5_CL_CORE_SRV_MODEL", "class": "ltcl_test_app_root4", "method": "test_tab_ref_gen", "note": "S-RTTI serialization calls CL_ABAP_TYPEDESCR=>describe_by_name with a dynamic type name, not supported in NodeJS runtime"}
     ]
   }
 }


### PR DESCRIPTION
## Summary
Updated the ABAP transpile configuration to exclude an additional test case from NodeJS runtime execution due to unsupported dynamic type descriptor functionality.

## Changes
- Added exclusion entry for `Z2UI5_CL_CORE_SRV_MODEL.ltcl_test_app_root4.test_tab_ref_gen` test method
- Documented that the test uses `CL_ABAP_TYPEDESCR=>describe_by_name` with dynamic type names, which is not supported in the NodeJS runtime environment

## Details
This change extends the existing list of known incompatibilities between ABAP and the NodeJS transpilation runtime. The S-RTTI (Static Runtime Type Information) serialization in this test relies on dynamic type descriptor lookups that cannot be executed in the NodeJS environment, requiring the test to be skipped during transpiled execution.

https://claude.ai/code/session_01TNqXdsWu2VpDcTbZWXPKnz