### PR TITLE
Simplify npm scripts and update abaplint dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ### Tasks
 ##### Downport & Transpile
 ```
-npm run init
+npm run clone
 npm run build
 ```
 ##### Run Unit Tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "abap2ui5",
+  "name": "web-abap2ui5",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "abap2ui5",
+      "name": "web-abap2ui5",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@abaplint/cli": "2.119.66",
+        "@abaplint/cli": "2.120.3",
         "@abaplint/database-sqlite": "^2.13.40",
         "@abaplint/runtime": "^2.13.40",
         "@abaplint/transpiler-cli": "^2.13.40",
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/@abaplint/cli": {
-      "version": "2.119.66",
-      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.119.66.tgz",
-      "integrity": "sha512-Anjsm5G0jUnWwEAZrk2Ckm0we+VCrwjc/MOMSSk+774VJ6ka1ovkj981Y8BJdbxcKgKzIvn+D/ddap/tdxMFbw==",
+      "version": "2.120.3",
+      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.120.3.tgz",
+      "integrity": "sha512-9Qdc9WpH5FbrOaDw/RsZ9qGJWGPKGv1ZTbGaGpUTv8qP8EYgGvga6XNXUPZkT2yJH0w1PEC5p0Zei6DwJZQGzw==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "clone1": "rm -rf abap2UI5 && git clone --depth=1 https://github.com/abap2UI5/abap2UI5 && cp -r abap2UI5/src src && cp src/99/02/z2ui5_cl_pop_*.clas.abap src/99/02/z2ui5_cl_pop_*.clas.xml src/02/ && ( cp src/99/z2ui5_cl_xml_view*.clas.* src/02/ 2>/dev/null || true ) && rm -rf src/99",
     "clone2": "rm -rf abap2UI5-samples && git clone --depth=1 --branch cloud https://github.com/abap2UI5/samples abap2UI5-samples && mkdir -p src/samples && cp -r abap2UI5-samples/src/. src/samples",
     "clone": "rm -rf src && npm run clone1 && npm run clone2",
-    "init_abap2ui5": "rm -rf src && rm -rf abap2UI5 &&  mkdir src && git clone --depth=1 https://github.com/abap2UI5/abap2UI5.git && cp -r abap2UI5/src/* src/ && cp src/99/02/z2ui5_cl_pop_*.clas.abap src/99/02/z2ui5_cl_pop_*.clas.xml src/02/ && ( cp src/99/z2ui5_cl_xml_view*.clas.* src/02/ 2>/dev/null || true ) && rm -rf src/99",
-    "init_samples": "rm -rf abap2UI5-samples && git clone --depth=1 --branch cloud https://github.com/abap2UI5/samples abap2UI5-samples && mkdir -p src/samples && cp -r abap2UI5-samples/src/. src/samples",
-    "init": "npm run init_abap2ui5 && npm run init_samples",
     "syfixes": "find . -type f -name '*.abap' -exec sed -i -e 's/ RAISE EXCEPTION TYPE cx_sy_itab_line_not_found/ ASSERT 1 = 0/g' {} + ",
     "downport": "rm -rf downport && cp -r src downport && node ci/patch_diss_oref.mjs && abaplint --fix ./ci/abaplint-downport.jsonc && npm run syfixes",
     "downport_samples": "rm -rf downport && cp -r src downport && node ci/patch_diss_oref.mjs && abaplint --fix ./ci/abaplint-downport-samples.jsonc && npm run syfixes",
@@ -21,9 +18,7 @@
     "serve:build": "node srv/serve_build.mjs",
     "webpack:run": "webpack serve --mode development --env development",
     "webpack:build": "webpack --mode development --env development",
-    "build": "npm ci && npm run downport && npm run transpile && rm -rf src",
-    "express_play": "node abap2UI5-transpiled/srv/express.mjs",
-    "init_play": "git clone https://github.com/abap2UI5/abap2UI5-transpiled && cd abap2UI5-transpiled && npm run init && npm run build && cd .."
+    "build": "npm ci && npm run downport && npm run transpile && rm -rf src"
   },
   "repository": {
     "type": "git",
@@ -35,7 +30,7 @@
   },
   "homepage": "https://github.com/abap2UI5/web-abap2UI5#readme",
   "devDependencies": {
-    "@abaplint/cli": "2.119.66",
+    "@abaplint/cli": "2.120.3",
     "@abaplint/database-sqlite": "^2.13.40",
     "@abaplint/runtime": "^2.13.40",
     "@abaplint/transpiler-cli": "^2.13.40",


### PR DESCRIPTION
## Summary
This PR streamlines the npm scripts in package.json by removing redundant initialization commands and updates the abaplint CLI dependency to a newer version.

## Key Changes
- **Removed redundant npm scripts**: Deleted `init_abap2ui5`, `init_samples`, and `init` scripts that duplicated functionality already present in `clone1`, `clone2`, and `clone` scripts
- **Removed unused scripts**: Deleted `express_play` and `init_play` scripts that were not part of the standard workflow
- **Updated documentation**: Changed README.md to reference `npm run clone` instead of the removed `npm run init` command
- **Updated dependency**: Bumped `@abaplint/cli` from version 2.119.66 to 2.120.3

## Implementation Details
The `clone` script already provides the complete initialization workflow by running `clone1` and `clone2` in sequence, making the separate `init_*` scripts unnecessary. This change reduces maintenance burden and makes the script interface clearer for users.

https://claude.ai/code/session_01PzMi9GSFJ1YeYSgFR152HG