### PR TITLE
Answer to npm run check

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "description": "abap2UI5 running fully in the browser - downported, transpiled to JS and bundled for GitHub Pages.",
   "scripts": {
+    "check": "npm run clone && npm test && npm run build:web",
     "clone": "rm -rf src && npm run clone:core && npm run clone:samples",
     "clone:core": "rm -rf abap2UI5 && git clone --depth=1 https://github.com/abap2UI5/abap2UI5 && cp -r abap2UI5/src src && rm -rf src/99",
     "clone:samples": "rm -rf abap2UI5-samples && git clone --depth=1 https://github.com/abap2UI5/samples abap2UI5-samples && mkdir -p src/samples && cp -r abap2UI5-samples/src/. src/samples",


### PR DESCRIPTION
# Description

`CONVENTIONS.md` section 3 asks every repository for **both** `npm run check` and `npm test`. This repository had `test` and not `check` — so the command that means "what will CI say about this tree" was the one thing a contributor could not run here.

`check` is `clone && test && build:web`: what `build_web.yaml` does on a pull request, in the same order. It stops before the Playwright e2e run, which needs a chromium install — section 3 allows an omission that needs something a checkout does not have.

**One thing worth reading twice:** `clone` does `rm -rf src` and re-fetches. That reads alarming for a command named `check`, and it is correct here — `src/` is gitignored and untracked, mirrored from abap2UI5 and samples on every run, and a build against a stale copy proves nothing. CI clones first for the same reason. The commit message says so too, so nobody has to rediscover it.

abap2UI5#2640 adds a `check:scripts` gate holding all ten repositories to this; it stays red until this one and its three siblings land.

Siblings: samples, samples-stack, samples-controls.

## How to test

```
npm ci && npm run check
```

Not run end-to-end here — it clones two repositories and runs a full downport + transpile, which is the CI job's runtime. The three commands it chains are unchanged and are what `build_web.yaml` already runs.

## Checklist

- [x] Composed from commands CI already runs, in CI's order
- [ ] Unit tests added/updated — not applicable; one `package.json` line
- [x] No pipeline behaviour changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLDFPfAK1MGq6qHeC6KKWH)_