### PR TITLE
Ask Dependabot monthly, and keep majors out of the routine bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,7 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
-      day: tuesday
+      interval: monthly
       # Well clear of the 08:00 UTC daily rebuild, so a Dependabot pull
       # request and the scheduled build do not fight for the runner.
       time: "05:30"
@@ -34,9 +33,19 @@ updates:
       abaplint:
         patterns:
           - "@abaplint/*"
+        update-types: ["minor", "patch"]
+      abaplint-major:
+        patterns:
+          - "@abaplint/*"
+        update-types: ["major"]
       toolchain:
         patterns:
           - "*"
+        update-types: ["minor", "patch"]
+      toolchain-major:
+        patterns:
+          - "*"
+        update-types: ["major"]
     ignore:
       # @abaplint/cli is pinned EXACTLY (no caret) to the version abap2UI5
       # itself syntax-checks with: the downport result has to pass the same
@@ -49,11 +58,15 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-      day: tuesday
+      interval: monthly
       time: "05:30"
     open-pull-requests-limit: 5
     groups:
       actions:
         patterns:
           - "*"
+        update-types: ["minor", "patch"]
+      actions-major:
+        patterns:
+          - "*"
+        update-types: ["major"]


### PR DESCRIPTION
# Description

Part of an ecosystem-wide change — the same edit lands in all ten repositories that carry a `dependabot.yml`.

Grouping was already at its limit (one group per ecosystem), so the volume came from **multiplication**: two to three ecosystems × ten repositories × every Tuesday ≈ **21 pull requests a week** for build-time tools.

**Monthly:** the same updates, a quarter as often.

**Majors travel alone:** each group is split by `update-types`, so a routine month produces one pull request per group with only minor and patch bumps, and a major arrives separately — visible as a major, and reviewable as one. `actions/download-artifact` 7 → 8 was merged in abap2UI5 today inside a group; it was clean, but it carried an ESM migration and a digest check that now fails a run instead of warning.

**Group order matters here** and was preserved. `abaplint` (`@abaplint/*`) is listed before `toolchain` (`*`), and the split keeps that order — `abaplint`, `abaplint-major`, `toolchain`, `toolchain-major` — so an `@abaplint/*` major lands in `abaplint-major` rather than falling through to the catch-all. The `ignore` entry pinning `@abaplint/cli` exactly is untouched: that one is still bumped by hand, together with abap2UI5's pin.

The header comment's promise still holds — every pull request here runs `build_web` (downport + transpile + unit tests + webpack + browser smoke), which remains the real verdict on a bump. Monthly changes how often it is asked, not what decides.

## How to test

Open the pull request and let `build_web` run — that is this repository's own answer to a dependency change.

## Checklist

- [x] YAML validated
- [x] Group order preserved so `@abaplint/*` majors do not fall through to the catch-all
- [x] `@abaplint/cli` ignore entry untouched

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLDFPfAK1MGq6qHeC6KKWH)_