### PR TITLE
Give the deploy pin its version comment, and retire the node24 forcing flag

### DIFF
--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -13,11 +13,6 @@ permissions:
   contents: read
   issues: write  # to report failed scheduled runs
 
-env:
-  # peaceiris/actions-gh-pages@v4 still ships with node20; force the runner to
-  # execute it on node24 until upstream publishes a node24-based release.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   build_web:
     runs-on: ubuntu-latest
@@ -139,8 +134,20 @@ jobs:
     # SHA-pinned like every other action here. This is the step that holds
     # DEPLOY_WEB and writes to the published repository, so it was the last
     # one that should have been tracking a mutable tag.
+    #
+    # The pin is the COMMIT, and the comment carries the full version. Both
+    # halves were wrong until 2026-08-18 and each cost something:
+    #
+    #   refs/tags/v4        = 329bcc8f   <- what was pinned: a tag OBJECT
+    #   refs/tags/v4^{}     = 84c30a85   <- the commit it dereferences to
+    #   refs/tags/v4.1.0^{} = 84c30a85   <- the same commit, under a version
+    #
+    # A tag object is not what "SHA-pinned" means anywhere else in this file,
+    # and a bare `# v4` is a version Dependabot cannot turn into an update
+    # type - so this action fell out of the `actions` group and arrived as its
+    # own pull request, which is the opposite of why the groups exist.
     - name: deploy to web-abap2UI5-build
-      uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
+      uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
       if: steps.upstream.outputs.changed == 'true' && github.ref == 'refs/heads/main' && github.repository == 'abap2UI5/web-abap2UI5'
       with:
         deploy_key: ${{ secrets.DEPLOY_WEB }}


### PR DESCRIPTION
# Description

Two things about `peaceiris/actions-gh-pages`, found while working out why it produced an **ungrouped** Dependabot pull request after the `update-types` split.

## The comment half of the pin

`329bcc8f` was the annotated **tag object** that `refs/tags/v4` is:

```
refs/tags/v4        = 329bcc8f   ← what was pinned
refs/tags/v4^{}     = 84c30a85   ← the commit it dereferences to
refs/tags/v4.1.0^{} = 84c30a85   ← the same commit, under a version
```

**Dependabot #75 has since merged and fixed the SHA half** — `main` now pins the commit. What it kept is `# v4`, and a bare `# v4` is a version Dependabot cannot turn into an update type, which is exactly why this action fell out of the `actions` group and arrived on its own. This rebase therefore carries only the remaining half: the full version in the comment, so the grouping works, plus the note explaining what was wrong with the old ref kind.

## The node24 flag has outlived its condition

```yaml
env:
  # peaceiris/actions-gh-pages@v4 still ships with node20; force the runner to
  # execute it on node24 until upstream publishes a node24-based release.
  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
```

That release exists and is the one being used. Every JS action this workflow can reach declares `node24` — read at the pinned commit rather than assumed:

| Action | `runs.using` |
|---|---|
| `peaceiris/actions-gh-pages@84c30a85` | node24 |
| `actions/checkout@3d3c42e5` | node24 |
| `actions/setup-node@82076278` | node24 |
| `actions/cache@55cc8345` | node24 |
| `actions/github-script@3a2844b7` | node24 — *inside the composite `report-scheduled-failure`* |

The flag is therefore a no-op, and the comment stating otherwise is exactly the kind of thing that outlives the condition it was written for.

## Why removing it is safe to verify rather than argue about

`build_web` is this repository's required check and it runs the whole pipeline **including this deploy step**, so the pull request proves it before anything reaches the published site. If the flag were still load-bearing, this PR goes red instead of the demo site going stale.

## How to test

`build_web` on this pull request — that is the same job that deploys, minus the push.

## Checklist

- [x] YAML validated
- [x] Every action's runtime read at its pinned commit, including the nested one
- [x] No behaviour change from the comment — same commit either way
- [x] Rebased onto `main` after #75 merged; the SHA line is now comment-only