### PR TITLE
Preserve z2ui5_if_exit interface during upstream src/99 removal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,20 @@ joins a namespace rather than inventing a bare name.
 Each of these was paid for with a broken deploy. The full story is in the
 comment at the code; this list exists so nobody deletes one without reading it.
 
+- **The `z2ui5_if_exit` copy-back in `clone:core`** (`package.json`). The clone
+  drops upstream's frozen `src/99` package, but one object in it is not dead
+  weight: `src/01/04/z2ui5_cl_ui5_user_exit` still declares a reference of type
+  `z2ui5_if_exit` and its test class still implements the interface, because
+  upstream keeps the superseded exit name working while the rename to
+  `z2ui5_if_ui5_exit` settles. Deleting the whole package therefore breaks the
+  downport with 10 unresolved-type / check_syntax errors — which is what every
+  scheduled build did from 2026-08-22 on, the morning after upstream retired
+  the interface into `src/99`. The interface (plus the package's
+  `package.devc.xml`) is copied back and nothing else; its three types are
+  declared AS the ones on `z2ui5_if_ui5_exit`, so it drags no further
+  dependency in. When upstream finally deletes `z2ui5_if_exit`, this copy-back
+  goes with it.
+
 - **`keep_classnames` / `keep_fnames` in the Terser options**
   (`webpack.config.js`). The transpiled ABAP carries its type system in the
   *names*: RTTI (`describe_by_data` and friends) reads class and function

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "check": "npm run clone && npm test && npm run build:web",
     "clone": "rm -rf src && npm run clone:core && npm run clone:samples",
-    "clone:core": "rm -rf abap2UI5 && git clone --depth=1 https://github.com/abap2UI5/abap2UI5 && cp -r abap2UI5/src src && rm -rf src/99",
+    "clone:core": "rm -rf abap2UI5 && git clone --depth=1 https://github.com/abap2UI5/abap2UI5 && cp -r abap2UI5/src src && rm -rf src/99 && mkdir -p src/99 && cp abap2UI5/src/99/package.devc.xml abap2UI5/src/99/z2ui5_if_exit.intf.abap abap2UI5/src/99/z2ui5_if_exit.intf.xml src/99/",
     "clone:samples": "rm -rf abap2UI5-samples && git clone --depth=1 https://github.com/abap2UI5/samples abap2UI5-samples && mkdir -p src/samples && cp -r abap2UI5-samples/src/. src/samples",
     "build": "npm run build:downport && npm run build:transpile && rm -rf src",
     "build:downport": "rm -rf downport && cp -r src downport && node ci/patch_diss_oref.mjs && abaplint --fix ./ci/abaplint-downport.jsonc && npm run build:syfixes",


### PR DESCRIPTION
## Summary
Updates the clone process to preserve the `z2ui5_if_exit` interface and its package metadata when removing the upstream `src/99` package. This prevents build failures caused by unresolved type references in code that still depends on the superseded interface name.

## Changes
- **AGENTS.md**: Added documentation explaining why the `z2ui5_if_exit` copy-back is necessary and load-bearing. The interface was moved upstream but kept temporarily for backward compatibility; removing it entirely breaks the downport with 10+ unresolved-type errors until upstream fully retires it.

- **package.json**: Modified the `clone:core` script to:
  - Continue removing the full `src/99` package as before
  - Recreate `src/99` directory
  - Copy back only three essential files: `package.devc.xml`, `z2ui5_if_exit.intf.abap`, and `z2ui5_if_exit.intf.xml`
  - The preserved interface is declared AS the replacement `z2ui5_if_ui5_exit`, avoiding additional dependencies

## Implementation Details
This is a targeted preservation of a single interface to maintain compatibility during an upstream transition period. The copy-back will be removed once upstream fully deletes `z2ui5_if_exit`, as documented in AGENTS.md.

https://claude.ai/code/session_01U74skEu9kmoKgHfhDQnsj7