### PR TITLE
Apply upstream's abaplint downport shim, without which npm test is red

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,27 @@ comment at the code; this list exists so nobody deletes one without reading it.
   instances only, named class by class: `Z2UI5_CL_UI5_*` as a wildcard would
   also catch the demo *apps*, whose attributes must be dissolved.
 
+- **The abaplint downport shim** (`abap2UI5/node/setup/patch-abaplint-downport.mjs`,
+  called from `build:downport` against *this* repo's `@abaplint/cli` bundle).
+  Stock abaplint outlines a component-level table expression
+  (`tab[ 1 ]-comp`) into a work AREA — a copy — so the row reference is gone
+  by the time the framework sees it, and `client->_bind( tab = … tab_index = … )`
+  refuses the cell with `BINDING_ERROR_TAB_CELL_LEVEL`. The shim makes the
+  outline `ASSIGNING`, which is what the same abaplint rule's write path
+  already emits.
+
+  It is upstream's script, run from the clone `clone:core` already makes,
+  never a copy: it is a temporary shim for an abaplint defect and it must
+  disappear from every consumer on the same day. The bundle path is passed
+  explicitly because the clone has no `node_modules` of its own — the default
+  would silently patch nothing here.
+
+  The canary is upstream's own `test_bind_tab_cell` (`z2ui5_cl_ui5_client`
+  test class), which `npm test` runs: without the shim that test is the one
+  red line in an otherwise green suite. That is how this was found — upstream
+  added the cell binding on 2026-08-30 and this pipeline, which downports the
+  same sources with a different abaplint install, had no shim to apply.
+
 - **`ci/patch_init_order.mjs`**. The transpiler emits static imports of async
   modules; ES only guarantees they *start* in order, not that each finishes
   before the next starts. Cross-class references made during

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clone:core": "rm -rf abap2UI5 && git clone --depth=1 https://github.com/abap2UI5/abap2UI5 && cp -r abap2UI5/src src && rm -rf src/99 && mkdir -p src/99 && cp abap2UI5/src/99/package.devc.xml abap2UI5/src/99/z2ui5_if_exit.intf.abap abap2UI5/src/99/z2ui5_if_exit.intf.xml src/99/",
     "clone:samples": "rm -rf abap2UI5-samples && git clone --depth=1 https://github.com/abap2UI5/samples abap2UI5-samples && mkdir -p src/samples && cp -r abap2UI5-samples/src/. src/samples",
     "build": "npm run build:downport && npm run build:transpile && rm -rf src",
-    "build:downport": "rm -rf downport && cp -r src downport && node ci/patch_diss_oref.mjs && abaplint --fix ./ci/abaplint-downport.jsonc && npm run build:syfixes",
+    "build:downport": "rm -rf downport && cp -r src downport && node ci/patch_diss_oref.mjs && node abap2UI5/node/setup/patch-abaplint-downport.mjs node_modules/@abaplint/cli/build/cli.js && abaplint --fix ./ci/abaplint-downport.jsonc && npm run build:syfixes",
     "build:syfixes": "find . -type f -name '*.abap' -exec sed -i -e 's/ RAISE EXCEPTION TYPE cx_sy_itab_line_not_found/ ASSERT 1 = 0/g' {} + ",
     "build:transpile": "rm -rf output && cp srv/*.abap downport && abap_transpile ./ci/abap_transpile.json && node ci/patch_init_order.mjs",
     "build:web": "webpack --mode production",


### PR DESCRIPTION
## What this changes

`npm run check` passes again. On `main` it fails in `npm test`, on `ltcl_test_client->test_bind_tab_cell`:

```
<ref *1> z2ui5_cx_ui5_util_error [Error]
    at z2ui5_cl_ui5_srv_bind.bind_tab_cell (output/z2ui5_cl_ui5_srv_bind.clas.mjs:147:30)
    at async z2ui5_cl_ui5_client.z2ui5_if_client$_bind (…:561:17)
    at async #test_bind_tab_cell (…testclasses.mjs:1069:122)
```

## Why

That test says why in its own comment — it is the **canary** for `abap2UI5/node/setup/patch-abaplint-downport.mjs`:

> Stock abaplint lowers `tab[ n ]-comp` to `READ TABLE ... INTO <wa>` - a copy, so the reference this binding matches on never arrives and the cell is refused. The patch makes the outline ASSIGNING […] this test is green in the transpiled suite only because the patch is applied. **If it starts failing, look at the patch before looking at the binding.**

`client->_bind( val = … tab = … tab_index = … )` identifies the bound cell by data reference. A work-area copy loses it, and the call comes back `BINDING_ERROR_TAB_CELL_LEVEL`.

This pipeline downports the same sources with its **own** `@abaplint/cli` install and had no shim to apply. So upstream adding the cell binding ([abap2UI5#2684](https://github.com/abap2UI5/abap2UI5/pull/2684), 2026-08-30) turned this repository red with no commit here. The shim's own comment lists its call sites — abap2UI5's `downport` script and samples-controls' `e2e-build.mjs` — and this was the third consumer, unlisted.

## How it is wired

```diff
-"build:downport": "… && node ci/patch_diss_oref.mjs && abaplint --fix ./ci/abaplint-downport.jsonc && …"
+"build:downport": "… && node ci/patch_diss_oref.mjs && node abap2UI5/node/setup/patch-abaplint-downport.mjs node_modules/@abaplint/cli/build/cli.js && abaplint --fix ./ci/abaplint-downport.jsonc && …"
```

Two deliberate choices:

- **Upstream's script from the clone `clone:core` already makes, never a copy.** It is a temporary shim for an abaplint defect filed upstream, and it has to disappear from every consumer on the same day. It also fails loudly rather than silently when its anchors stop matching, which is the signal that abaplint shipped the fix.
- **The bundle path is passed explicitly.** The script's default resolves `../../node_modules/@abaplint/cli/build/cli.js` relative to itself, and that clone has no `node_modules` of its own — the default would have patched nothing and said so cheerfully.

`AGENTS.md` gains an entry under the load-bearing patches, next to `patch_diss_oref.mjs` and `patch_init_order.mjs`.

## Verification

From a **stock** `@abaplint/cli` 2.120.3 bundle (restored from a backup before the run), a full `npm run clone && npm test`:

```
patch-abaplint-downport: 3 edit(s) applied - node_modules/@abaplint/cli/build/cli.js
…
[whole transpiled suite green, including test_bind_tab_cell]
```

## Worth knowing

`abap2UI5/playground` has the same gap — it also runs `abaplint --fix` with no shim, and is green today only because its framework pin (`67f214d`) predates the cell binding. Its next pin bump breaks the same way, except the symptom there is a runtime `BINDING_ERROR_TAB_CELL_LEVEL` in the browser rather than a failing unit test. Not fixed here; filed as a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01472ydUNKidXgDH29MLq4Cw)_