### PR TITLE
Route the UI5 1.152 Request-shaped fetch back into the in-browser backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,22 @@ comment at the code; this list exists so nobody deletes one without reading it.
   running wasm/eval runtime while protecting nothing — there is no network
   backend in this demo.
 
+- **The Request branch of the fetch override** (`app/web.mjs`). The override
+  routes a `fetch()` addressed to this page into the transpiled backend, and it
+  has to recognize the target in all three argument shapes the Fetch API takes:
+  a string, a `URL` — and a `Request`. The last one is not hypothetical.
+  OpenUI5 1.152 ships `sap/ui/performance/FetchInterceptor`, which wraps
+  whatever `globalThis.fetch` is when it loads (this override) and always calls
+  it as `fetch(new Request(...))`, folding the init object into the request. A
+  string-or-URL-only test therefore stopped matching, every backend POST fell
+  through to the network and came back as the static server's 404
+  `Cannot POST /`: the page booted, rendered nothing and answered no button.
+  Nothing in this repository or upstream changed that day — the page boots UI5
+  from the *cachebuster* URL, so the CDN flipping to 1.152 was enough to turn
+  the same commit red. For the same reason `backendFetch` answers with a real
+  `Response` and not a duck-typed look-alike: the interceptor hands the
+  returned object to its `onResponse` hooks, which `clone()` it.
+
 - **`ci/patch_diss_oref.mjs`**. `DISS_OREF` resolves attribute chains through
   the *dynamic* type in the transpiler runtime, so `dissolve()` walks from the
   app's `CLIENT` down into the framework core and the draft save clears the

--- a/app/web.mjs
+++ b/app/web.mjs
@@ -16,7 +16,12 @@ import {initializeABAP} from "../output/_init.mjs";
 await initializeABAP();
 
 // ---- backend fetch: routes a browser fetch into the transpiled ABAP backend ----
-async function backendFetch(url, options = {}) {
+// Takes the same argument shapes the Fetch API does - (url, init) AND a single
+// Request instance - because that is what actually reaches us, see the
+// FetchInterceptor note at the override below.
+async function backendFetch(input, options = {}) {
+  const request = await readRequest(input, options);
+  const url = request.url;
   let status = 200;
   let body = Buffer.alloc(0);
   const headers = new Map();
@@ -37,32 +42,61 @@ async function backendFetch(url, options = {}) {
     },
   };
 
-  // express lowercases request header names; the shim iterates them as-is.
-  const reqHeaders = {};
-  for (const [name, value] of Object.entries(options.headers || {})) {
-    reqHeaders[name.toLowerCase()] = String(value);
-  }
-
   const req = {
     // The shim reads req.body.toString("hex"), so this must be a real Buffer
     // (empty for GET/HEAD - Server.endSession sends a body-less HEAD).
-    body: Buffer.from(options.body || ""),
-    method: options.method || "GET",
-    headers: reqHeaders,
+    body: request.body,
+    method: request.method,
+    // express lowercases request header names; the shim iterates them as-is.
+    headers: request.headers,
     path: new URL(url, window.location.href).pathname,
-    url: String(url),
+    url,
   };
 
   await abap.Classes["CL_EXPRESS_ICF_SHIM"].run({req, res, class: "ZCL_SICF"});
 
-  const text = body.toString();
-  return {
-    ok: status >= 200 && status < 300,
+  // A REAL Response, not a hand-rolled look-alike. The FetchInterceptor below
+  // hands whatever this returns to its onResponse hooks, and those call
+  // .clone() on it - a duck-typed object with ok/status/text/json survives
+  // only for as long as nobody registers a hook. Response also gives the
+  // frontend the Headers contract (case-insensitive get, null when absent)
+  // for free, which is all the hand-rolled map ever provided.
+  // 204/205/304 must be constructed body-less - the ETag path answers 304.
+  const hasBody = status !== 204 && status !== 205 && status !== 304;
+  return new Response(hasBody ? body : null, {
     status,
-    headers: {get: (name) => headers.get(String(name).toLowerCase()) ?? null},
-    text: async () => text,
-    json: async () => JSON.parse(text),
+    headers: Object.fromEntries(headers),
+  });
+}
+
+// Read a fetch() call - in either argument shape - down to the four fields
+// the ICF shim needs. A Request carries method, headers and body itself, so
+// an init object is only consulted for the (url, init) shape.
+async function readRequest(input, options) {
+  if (isRequest(input)) {
+    return {
+      url: input.url,
+      method: input.method,
+      // Headers already lowercases the field names it iterates.
+      headers: Object.fromEntries(input.headers),
+      // Resolves to an empty buffer for a body-less request (GET/HEAD).
+      body: Buffer.from(await input.arrayBuffer()),
+    };
+  }
+  const headers = {};
+  for (const [name, value] of Object.entries(options.headers || {})) {
+    headers[name.toLowerCase()] = String(value);
+  }
+  return {
+    url: String(input),
+    method: options.method || "GET",
+    headers,
+    body: Buffer.from(options.body || ""),
   };
+}
+
+function isRequest(input) {
+  return typeof Request !== "undefined" && input instanceof Request;
 }
 
 // ---- fetch override: only intercept requests addressed to "this page" ----
@@ -70,14 +104,30 @@ async function backendFetch(url, options = {}) {
 // Compare origin + pathname instead of the full href: the hash changes at
 // runtime (SET_PUSH_STATE / History control), while sql-wasm.wasm (different
 // pathname) and the UI5 CDN (different origin) must reach the network.
+//
+// The first argument is every shape the Fetch API accepts - a string, a URL,
+// AND a Request. The Request shape is not theoretical: OpenUI5 1.152 ships
+// sap/ui/performance/FetchInterceptor, which wraps whatever globalThis.fetch
+// is when it loads (this override) and calls it as fetch(new Request(...)) -
+// "always construct a Request from the arguments", so the init object is
+// folded in and never reaches us separately. This page boots UI5 from the
+// cachebuster URL, i.e. always the newest release: on the day the CDN flipped
+// to 1.152 every backend POST stopped matching a string-or-URL-only test,
+// fell through to the network and came back as the static server's 404
+// "Cannot POST /" - a page that boots, renders nothing and answers no button.
+// The commit that was deployed did not change; the CDN did. That is why the
+// browser smoke gate exists.
 const nativeFetch = globalThis.fetch.bind(globalThis);
 
 function isBackendUrl(input) {
-  if (typeof input !== "string" && !(input instanceof URL)) {
+  const href = isRequest(input) ? input.url
+    : (typeof input === "string" || input instanceof URL) ? String(input)
+    : null;
+  if (href === null) {
     return false;
   }
   try {
-    const target = new URL(String(input), window.location.href);
+    const target = new URL(href, window.location.href);
     return target.origin === window.location.origin
         && target.pathname === window.location.pathname;
   } catch {
@@ -86,7 +136,7 @@ function isBackendUrl(input) {
 }
 
 globalThis.fetch = (input, options) =>
-  isBackendUrl(input) ? backendFetch(String(input), options) : nativeFetch(input, options);
+  isBackendUrl(input) ? backendFetch(input, options) : nativeFetch(input, options);
 
 // ---- boot: GET the frontend from the transpiled backend, replace the document ----
 try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@abaplint/cli": "2.120.33",
+        "@abaplint/cli": "2.120.38",
         "@abaplint/database-sqlite": "^2.13.40",
         "@abaplint/runtime": "^2.13.40",
         "@abaplint/transpiler-cli": "^2.13.40",
@@ -27,12 +27,15 @@
         "webpack": "^5.108.4",
         "webpack-cli": "^7.2.1",
         "webpack-dev-server": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@abaplint/cli": {
-      "version": "2.120.33",
-      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.120.33.tgz",
-      "integrity": "sha512-M+nDlBxNxDEB3LNqZOX7YAFxar7rRD3+9bN7Pecn7wSMXho3wuxzxWH9Lx3+78yHNUJa96jWFpKuA7Xe3VE5sw==",
+      "version": "2.120.38",
+      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.120.38.tgz",
+      "integrity": "sha512-aBnYQ4tE6k0Xzev7qH8dcOEsQRyrADPSorG+U3sv1v0SKgRbokhZ38rVV6mmZMtZUaWe6NB3zYX1G7R1zTvqfA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/abap2UI5/web-abap2UI5#readme",
   "devDependencies": {
-    "@abaplint/cli": "2.120.33",
+    "@abaplint/cli": "2.120.38",
     "@abaplint/database-sqlite": "^2.13.40",
     "@abaplint/runtime": "^2.13.40",
     "@abaplint/transpiler-cli": "^2.13.40",


### PR DESCRIPTION
Unblocks the two open Dependabot pull requests (#81, #82). Both are red, and neither for a reason in its own diff — `main` is red on the same head commit, so this has to land first.

## Two breakages, both from outside this repository

**1. The browser smoke, red since 2026-08-31 afternoon.** The same commit (`3fbbd3e`) was green in the morning push run and red in the afternoon scheduled run. Nothing here or upstream changed in between — the CDN did.

OpenUI5 **1.152** ships `sap/ui/performance/FetchInterceptor`. It wraps whatever `globalThis.fetch` is when it loads — this repo's backend override in `app/web.mjs` — and calls it as `fetch(new Request(...))`: *"always construct a Request from the arguments"*, so the init object is folded into the request and never arrives separately. `isBackendUrl` only recognized a string or a `URL`, so every backend POST fell through to the real network and came back as the static build server's 404 `Cannot POST /`. The page booted, rendered nothing, and would have deployed as a demo where no button works. This page boots UI5 from the *cachebuster* URL — always the newest release — which is why the CDN flip alone was enough.

The override now reads the target out of a `Request` too, and `backendFetch` takes both argument shapes: a `Request` already carries method, headers and body, so the init object is only consulted for the `(url, init)` shape. It also answers with a real `Response` instead of the duck-typed look-alike — the interceptor hands the returned object to its `onResponse` hooks and those `clone()` it, which the look-alike cannot survive. 204/205/304 are constructed body-less, since the backend's ETag path answers 304.

**2. The abaplint pin fell out of lockstep.** Upstream bumped its own pin to `^2.120.38` on 2026-09-01. `ci/check-abaplint-pin.mjs` runs inside `npm run clone`, ahead of the build, so this is what CI fails on *first* now — before it ever reaches the smoke test. `@abaplint/cli` moves `2.120.33` → `2.120.38`, by hand and in lockstep, as AGENTS.md "Pins" requires.

## Verification

The sandbox cannot reach `sdk.openui5.org`, so the boot was verified against the OpenUI5 1.152 npm distribution served in its place:

- **before** the change: the POST leaves for the network, the static server answers `404 Cannot POST /`, `z2ui5.oResponse` stays `null` — the exact CI failure;
- **after**: the boot reaches `oResponse`, no request leaks to the network.

`tests/web.spec.js` "event roundtrip restores the saved draft (BUTTON_CHECK)" and the transpiled unit suite (`npm test`) stay green; `npm run build:web` is clean.

## Docs

AGENTS.md gains the `Request` branch under "Things that look removable and are not" — the argument-shape test looks like defensive noise and is the whole fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fqjtiPdVFtPh9AniM7Wic

---
_Generated by [Claude Code](https://claude.ai/code/session_018fqjtiPdVFtPh9AniM7Wic)_