### PR TITLE
Read the transpiler skip list and the downport rule set from upstream instead of copying them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ playwright-report
 test-results
 media-out
 ci/abap_transpile.run.json
+ci/abaplint-downport.run.jsonc

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ src
 playwright-report
 test-results
 media-out
+ci/abap_transpile.run.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,25 @@ comment at the code; this list exists so nobody deletes one without reading it.
   the path, because a silent fall back to the local half would be the drift
   again, only quieter.
 
+- **`ci/merge_downport_config.mjs`, and the near-empty
+  `ci/abaplint-downport.jsonc` it completes.** Which abaplint rules run
+  alongside `downport`, and which syntax version they judge against, is a fact
+  about abap2UI5, not about this pipeline: the downport result here has to
+  pass the same check as upstream's source. That is the same rule the
+  `@abaplint/cli` pin follows under "Pins", and `ci/check-abaplint-pin.mjs`
+  already enforces the version half of it.
+
+  The rules half was a hand-written copy of upstream's
+  `.github/abaplint/abap_702.jsonc` — and it had already drifted, unnoticed:
+  upstream runs `xml_bom`, the copy did not. Nothing would ever have said so.
+
+  So rules and syntax are read from the clone. The checked-in file keeps only
+  what is genuinely this pipeline's — `global.files` and the dependency
+  folder, whose paths are relative to `ci/` and mean nothing upstream — plus a
+  `rules` object for local OVERRIDES, which is empty and correct that way. A
+  moved or reshaped upstream config fails the build with the path in the
+  message, for the same reason as the skip list above.
+
 - **`ci/patch_init_order.mjs`**. The transpiler emits static imports of async
   modules; ES only guarantees they *start* in order, not that each finishes
   before the next starts. Cross-class references made during

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ abap2UI5, not here.
 
 | Path | What it is |
 |---|---|
-| `ci/` | downport config + the two post-processing patches (below) |
+| `ci/` | transpile + downport config, the gates that keep them in lockstep with upstream, and the post-processing patches (below) |
 | `srv/` | Node-side entry points: express host, static build server, `ZCL_SICF` |
 | `app/` | browser entry: `web.mjs` (boot), `index.html`, `css/`, `pages/` |
 | `app/pages/` | README + 404 page copied into the deploy — the artifact repo's own files |
@@ -115,6 +115,34 @@ comment at the code; this list exists so nobody deletes one without reading it.
   red line in an otherwise green suite. That is how this was found — upstream
   added the cell binding on 2026-08-30 and this pipeline, which downports the
   same sources with a different abaplint install, had no shim to apply.
+
+- **`ci/merge_transpile_skips.mjs`, and the empty `skip` array it fills**
+  (`ci/abap_transpile.json`). A few abap2UI5 unit tests cannot pass under the
+  transpiler — they cover behaviour the NodeJS runtime does not reproduce
+  (a dynamic `describe_by_name`, microsecond timestamps, a field-symbol type
+  check the runtime does not enforce). abap2UI5 lists them in
+  `node/setup/abap_transpile.json`, in the same commit as the test.
+
+  This repository transpiles those same sources and kept a hand-written
+  SECOND COPY of that list. The copy is what broke the nightly on 2026-08-03
+  (issue #63, `test_tab_ref_gen`) and again on 2026-09-02 (issue #84,
+  `test_skip_sorted_table`): upstream added the test and its skip entry
+  together, the clone here picked up the test and knew nothing about the
+  entry, and the build went red on a test upstream had already declared
+  unrunnable. The second time the skip entry was 57 minutes old.
+
+  So the list is read from the clone `clone:core` already makes, never
+  copied — same reasoning as the abaplint downport shim above. The checked-in
+  `skip` array holds only entries upstream does NOT have; it is empty today
+  and an empty array is the correct state, not an oversight. The one entry it
+  used to carry alone — `ltcl_parser_test->parse_error`, noted "NodeJS 20 does
+  not set position of parsing error" — was stale: the pipeline runs Node 22,
+  the test passes, and skipping it had been hiding a green test for as long as
+  nobody re-read the note.
+
+  A missing or reshaped upstream list fails the build with a message naming
+  the path, because a silent fall back to the local half would be the drift
+  again, only quieter.
 
 - **`ci/patch_init_order.mjs`**. The transpiler emits static imports of async
   modules; ES only guarantees they *start* in order, not that each finishes

--- a/ci/abap_transpile.json
+++ b/ci/abap_transpile.json
@@ -24,12 +24,6 @@
       "reposrc": false
     },
     "keywords": ["return", "in", "class", "for", "delete", "var", "with"],
-    "skip": [
-      {"object": "Z2UI5_CL_AJSON", "class": "ltcl_parser_test", "method": "parse_error", "note": "NodeJS 20 does not set position of parsing error"},
-      {"object": "Z2UI5_CL_AJSON", "class": "ltcl_parser_test", "method": "unicode_characters", "note": "CL_ABAP_CONV_IN_CE=>uccpi dynamic call not supported in NodeJS runtime"},
-      {"object": "Z2UI5_CL_AJSON", "class": "ltcl_writer_test", "method": "set_timestampl", "note": "NodeJS timestamp precision is milliseconds, ABAP expects microseconds"},
-      {"object": "Z2UI5_CL_AJSON", "class": "ltcl_abap_to_json", "method": "set_value_timestampl", "note": "NodeJS timestamp precision is milliseconds, ABAP expects microseconds"},
-      {"object": "Z2UI5_CL_UI5_SRV_MODEL", "class": "ltcl_test_app_root4", "method": "test_tab_ref_gen", "note": "S-RTTI serialization calls CL_ABAP_TYPEDESCR=>describe_by_name with a dynamic type name, not supported in NodeJS runtime"}
-    ]
+    "skip": []
   }
 }

--- a/ci/abaplint-downport.jsonc
+++ b/ci/abaplint-downport.jsonc
@@ -9,23 +9,5 @@
       "files": "/src/**/*.*"
     }
   ],
-  "syntax": {
-    "version": "v702",
-    "errorNamespace": "."
-  },
-  "rules": {
-    "downport": true,
-    "begin_end_names": true,
-    "check_ddic": true,
-    "check_include": true,
-    "check_syntax": true,
-    "global_class": true,
-    "definitions_top": true,
-    "implement_methods": true,
-    "method_implemented_twice": true,
-    "parser_error": true,
-    "superclass_final": true,
-    "unknown_types": true,
-    "xml_consistency": true
-  }
+  "rules": {}
 }

--- a/ci/merge_downport_config.mjs
+++ b/ci/merge_downport_config.mjs
@@ -1,0 +1,110 @@
+/*
+ * The downport RULE SET is upstream's, not ours.
+ *
+ * `build:downport` runs abaplint's `downport` rule over a copy of upstream's
+ * sources to produce 7.02-compatible ABAP. Which rules run alongside it, and
+ * which syntax version they judge against, is a fact about abap2UI5: the
+ * downport result here has to pass the same check as upstream's own source.
+ * That is the same rule AGENTS.md states for the `@abaplint/cli` pin, and
+ * `ci/check-abaplint-pin.mjs` already enforces the version half of it.
+ *
+ * The rules half was a hand-written copy of upstream's
+ * `.github/abaplint/abap_702.jsonc`, and it had already drifted: upstream
+ * runs `xml_bom`, this copy did not, and nothing anywhere would have said so.
+ * That is the shape of failure this pipeline keeps paying for - see the
+ * transpiler skip list next to it in AGENTS.md, where the same silent copy
+ * cost issue #63 and issue #84.
+ *
+ * So the rules and the syntax version are read from the clone `clone:core`
+ * already makes. `ci/abaplint-downport.jsonc` stays the checked-in base and
+ * keeps what is genuinely THIS pipeline's: `global.files` and the dependency
+ * folder, whose paths are relative to `ci/` and have nothing to do with
+ * upstream's layout. Its `rules` object holds only local OVERRIDES - a rule
+ * this repository must switch off or configure differently for a reason of
+ * its own. It is empty today, and empty is the correct state.
+ *
+ * Upstream moving off 7.02, or renaming the file, fails the build here with
+ * the path in the message. Deliberately: a silent fall back to the last
+ * copied rule set is how the copy stopped matching in the first place.
+ */
+import fs from "node:fs";
+
+const BASE = "ci/abaplint-downport.jsonc";
+const UPSTREAM = "abap2UI5/.github/abaplint/abap_702.jsonc";
+const OUT = "ci/abaplint-downport.run.jsonc";
+
+const die = (msg) => {
+  console.error(`merge_downport_config: ${msg}`);
+  process.exit(1);
+};
+
+/* abaplint reads .jsonc, so a comment may appear in either file any day. A
+ * naive comment strip eats the `//` of the open-abap dependency URL, so this
+ * tracks string state instead of pattern-matching. */
+function parseJsonc(text, where) {
+  let out = "";
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inString) {
+      out += c;
+      if (escaped) escaped = false;
+      else if (c === "\\") escaped = true;
+      else if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      out += c;
+      continue;
+    }
+    if (c === "/" && text[i + 1] === "/") {
+      while (i < text.length && text[i] !== "\n") i++;
+      out += "\n";
+      continue;
+    }
+    if (c === "/" && text[i + 1] === "*") {
+      const end = text.indexOf("*/", i + 2);
+      i = end === -1 ? text.length : end + 1;
+      continue;
+    }
+    out += c;
+  }
+  try {
+    return JSON.parse(out);
+  } catch (e) {
+    die(`${where} is not valid JSON/JSONC: ${e.message}`);
+  }
+}
+
+const readOr = (file, what) => {
+  try {
+    return fs.readFileSync(file, "utf8");
+  } catch (e) {
+    die(`cannot read ${file} (${e.code ?? e.message}) - it is the source of ${what}.\n`
+      + "  Run `npm run clone` first; if upstream moved or renamed the file, point UPSTREAM here at the new path.");
+  }
+};
+
+const up = parseJsonc(readOr(UPSTREAM, "the downport rule set"), UPSTREAM);
+if (!up.rules || typeof up.rules !== "object") die(`${UPSTREAM} has no rules object - upstream changed the config shape, update this script`);
+if (!up.syntax) die(`${UPSTREAM} has no syntax block - upstream changed the config shape, update this script`);
+
+const base = parseJsonc(fs.readFileSync(BASE, "utf8"), BASE);
+if (!base.global?.files) die(`${BASE} must keep global.files - it is this pipeline's path, not upstream's`);
+if (!base.dependencies) die(`${BASE} must keep dependencies - the folder is this pipeline's, not upstream's`);
+
+const overrides = base.rules ?? {};
+const run = {
+  global: base.global,
+  dependencies: base.dependencies,
+  syntax: up.syntax,
+  rules: { ...up.rules, ...overrides },
+};
+fs.writeFileSync(OUT, `${JSON.stringify(run, null, 2)}\n`);
+
+const names = Object.keys(overrides);
+console.log(`merge_downport_config: ${Object.keys(up.rules).length} rules from abap2UI5 (syntax ${up.syntax.version})`
+  + `${names.length ? `, ${names.length} local override(s): ${names.join(", ")}` : ""}`
+  + ` -> ${OUT}`);

--- a/ci/merge_transpile_skips.mjs
+++ b/ci/merge_transpile_skips.mjs
@@ -1,0 +1,76 @@
+/*
+ * The transpiler's `skip` list is upstream's, not ours.
+ *
+ * A handful of abap2UI5 unit tests cannot pass under @abaplint/transpiler,
+ * because they cover behaviour the NodeJS runtime does not reproduce - a
+ * dynamic `describe_by_name`, microsecond timestamps, or a field-symbol type
+ * check the runtime does not enforce. abap2UI5 knows which ones and lists
+ * them in `node/setup/abap_transpile.json`, right next to the test it adds.
+ *
+ * This repository transpiles those same sources, so it needs the same list -
+ * and it kept a hand-written SECOND COPY of it. That copy is what broke the
+ * nightly on 2026-08-03 (issue #63, `test_tab_ref_gen`) and again on
+ * 2026-09-02 (issue #84, `test_skip_sorted_table`): upstream added a test and
+ * its skip entry in one commit, the clone here picked up the test and knew
+ * nothing about the entry, and a build that was correct in every other
+ * respect went red on a test upstream had already declared unrunnable. The
+ * second time the skip entry was 57 minutes old.
+ *
+ * So the list is no longer copied. `clone:core` already puts upstream's
+ * checkout in `abap2UI5/`; this reads the skip array out of it and writes the
+ * config the transpiler actually runs. Same reasoning as the abaplint
+ * downport shim in AGENTS.md: it is upstream's file, run from the clone,
+ * never a copy.
+ *
+ * `ci/abap_transpile.json` stays the checked-in base and keeps everything
+ * about THIS pipeline (folders, setup hook, keywords). Its own `skip` array
+ * now holds only the entries upstream does not have - a skip that is ours,
+ * for a reason that is ours. The two are unioned; upstream wins on a
+ * duplicate, so an entry upstream adopts stops being maintained here without
+ * anyone having to notice.
+ *
+ * Missing or unreadable upstream list = hard failure, deliberately. The whole
+ * point is that this repository stops guessing what upstream skips: a build
+ * that silently fell back to the local half would be the drift again, just
+ * quieter. When upstream moves the file, the message below names the path and
+ * the fix is one line here.
+ */
+import fs from "node:fs";
+
+const BASE = "ci/abap_transpile.json";
+const UPSTREAM = "abap2UI5/node/setup/abap_transpile.json";
+const OUT = "ci/abap_transpile.run.json";
+
+const die = (msg) => {
+  console.error(`merge_transpile_skips: ${msg}`);
+  process.exit(1);
+};
+
+let up;
+try {
+  up = JSON.parse(fs.readFileSync(UPSTREAM, "utf8"));
+} catch (e) {
+  die(`cannot read ${UPSTREAM} (${e.code ?? e.message}) - it is the source of the skip list.\n`
+    + "  Run `npm run clone` first; if upstream moved or renamed the file, point UPSTREAM here at the new path.");
+}
+
+const upSkip = up.options?.skip;
+if (!Array.isArray(upSkip)) {
+  die(`${UPSTREAM} has no options.skip array - upstream changed the config shape, update this script`);
+}
+
+const base = JSON.parse(fs.readFileSync(BASE, "utf8"));
+const ownSkip = base.options?.skip ?? [];
+
+// object/class/method identify a skipped test method; the note is prose
+const key = (s) => [s.object, s.class, s.method].map((v) => String(v ?? "").toUpperCase()).join("|");
+const seen = new Set(upSkip.map(key));
+const own = ownSkip.filter((s) => !seen.has(key(s)));
+const dropped = ownSkip.length - own.length;
+
+base.options.skip = [...upSkip, ...own];
+fs.writeFileSync(OUT, `${JSON.stringify(base, null, 2)}\n`);
+
+console.log(`merge_transpile_skips: ${upSkip.length} skips from abap2UI5 + ${own.length} local`
+  + `${dropped ? ` (${dropped} local entr${dropped === 1 ? "y" : "ies"} upstream now carries)` : ""}`
+  + ` -> ${OUT}`);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clone:core": "rm -rf abap2UI5 && git clone --depth=1 https://github.com/abap2UI5/abap2UI5 && cp -r abap2UI5/src src && rm -rf src/99 && mkdir -p src/99 && cp abap2UI5/src/99/package.devc.xml abap2UI5/src/99/z2ui5_if_exit.intf.abap abap2UI5/src/99/z2ui5_if_exit.intf.xml src/99/",
     "clone:samples": "rm -rf abap2UI5-samples && git clone --depth=1 https://github.com/abap2UI5/samples abap2UI5-samples && mkdir -p src/samples && cp -r abap2UI5-samples/src/. src/samples",
     "build": "npm run build:downport && npm run build:transpile && rm -rf src",
-    "build:downport": "rm -rf downport && cp -r src downport && node ci/patch_diss_oref.mjs && node abap2UI5/node/setup/patch-abaplint-downport.mjs node_modules/@abaplint/cli/build/cli.js && abaplint --fix ./ci/abaplint-downport.jsonc && npm run build:syfixes",
+    "build:downport": "rm -rf downport && cp -r src downport && node ci/patch_diss_oref.mjs && node abap2UI5/node/setup/patch-abaplint-downport.mjs node_modules/@abaplint/cli/build/cli.js && node ci/merge_downport_config.mjs && abaplint --fix ./ci/abaplint-downport.run.jsonc && npm run build:syfixes",
     "build:syfixes": "find . -type f -name '*.abap' -exec sed -i -e 's/ RAISE EXCEPTION TYPE cx_sy_itab_line_not_found/ ASSERT 1 = 0/g' {} + ",
     "build:transpile": "rm -rf output && cp srv/*.abap downport && node ci/merge_transpile_skips.mjs && abap_transpile ./ci/abap_transpile.run.json && node ci/patch_init_order.mjs",
     "build:web": "webpack --mode production",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "npm run build:downport && npm run build:transpile && rm -rf src",
     "build:downport": "rm -rf downport && cp -r src downport && node ci/patch_diss_oref.mjs && node abap2UI5/node/setup/patch-abaplint-downport.mjs node_modules/@abaplint/cli/build/cli.js && abaplint --fix ./ci/abaplint-downport.jsonc && npm run build:syfixes",
     "build:syfixes": "find . -type f -name '*.abap' -exec sed -i -e 's/ RAISE EXCEPTION TYPE cx_sy_itab_line_not_found/ ASSERT 1 = 0/g' {} + ",
-    "build:transpile": "rm -rf output && cp srv/*.abap downport && abap_transpile ./ci/abap_transpile.json && node ci/patch_init_order.mjs",
+    "build:transpile": "rm -rf output && cp srv/*.abap downport && node ci/merge_transpile_skips.mjs && abap_transpile ./ci/abap_transpile.run.json && node ci/patch_init_order.mjs",
     "build:web": "webpack --mode production",
     "test": "npm run build && npm run test:unit",
     "test:unit": "node output/index.mjs",


### PR DESCRIPTION
Fixes #84, and the class of failure behind it.

## What broke today

- **11:41** — abap2UI5 merged [abap2UI5/abap2UI5#2704](https://github.com/abap2UI5/abap2UI5/pull/2704): a new test `ltcl_test_delta_apply->test_skip_sorted_table` **and**, in the same commit, the `skip` entry in `node/setup/abap_transpile.json` saying that test cannot run under the transpiler.
- **12:38** — the nightly cloned upstream, picked up the test and not the entry, and failed with `Expected '299', got '1250'` ([run 33630929149](https://github.com/abap2UI5/web-abap2UI5/actions/runs/33630929149)).

The test is right. `ASSIGN` of a SORTED table to a `TYPE STANDARD TABLE` field symbol gives `sy-subrc = 4` on a real system — that is the refusal branch `delta_apply_to_table` relies on. The NodeJS runtime does not enforce field-symbol typing, the `ASSIGN` succeeds there, and the delta is applied. Upstream knew and had already declared it unrunnable. The skip entry was 57 minutes old when this build consumed it.

The defect is not the check. It is that `ci/abap_transpile.json` held a **second, hand-written copy** of a list that belongs to upstream.

## Not the first time

Issue #63 (2026-08-03) was the same failure with `test_tab_ref_gen`, fixed by adding one more line to the copy. Five of the last seven nightly breakages are this shape: a fact about upstream, transcribed here, that upstream then changed.

The repository's own conventions already point the other way — `patch_diss_oref.mjs`, `patch_init_order.mjs` and `check-abaplint-pin.mjs` all fail loudly when upstream moves, and the abaplint downport shim is deliberately run from the clone rather than copied (AGENTS.md says so in as many words). The two configs were the places that instead carried a silent copy.

## What this does

Two scripts, both reading out of the clone `clone:core` already makes:

| | reads | writes |
|---|---|---|
| `ci/merge_transpile_skips.mjs` | `abap2UI5/node/setup/abap_transpile.json` → `options.skip` | `ci/abap_transpile.run.json` |
| `ci/merge_downport_config.mjs` | `abap2UI5/.github/abaplint/abap_702.jsonc` → `rules`, `syntax` | `ci/abaplint-downport.run.jsonc` |

The checked-in files keep only what is genuinely this pipeline's — folders, the setup hook, `keywords`, `global.files`, the dependency folder — plus an array/object for entries this repository declares **on its own**. Both are empty today, and empty is the correct state, not an oversight.

A missing or reshaped upstream file **fails the build** with the path in the message. That is deliberate: a silent fall back to the local half would be the same drift, only quieter.

## Two things fell out of it

- **`xml_bom` was missing.** The downport rule set had already drifted — upstream runs 14 rules, this copy ran 13 — and nothing anywhere would have reported it. It is back, and the build is green with it.
- **A stale skip was hiding a green test.** `ltcl_parser_test->parse_error` was skipped for *"NodeJS 20 does not set position of parsing error"*. The pipeline runs Node 22; the test passes. It runs again.

## Verification

`npm run clone && npm test` against upstream `1d571fc`:

```
merge_downport_config: 14 rules from abap2UI5 (syntax v702) -> ci/abaplint-downport.run.jsonc
merge_transpile_skips: 8 skips from abap2UI5 + 0 local -> ci/abap_transpile.run.json
… test_skip_sorted_table, skipped due to configuration
… ltcl_parser_test->parse_error                          (runs, green)
EXIT=0
```

Both scripts were also checked the other way — each reports and exits 1 when the upstream file is moved away or its key renamed.

## Companion change upstream

[abap2UI5/abap2UI5#2706](https://github.com/abap2UI5/abap2UI5/pull/2706) declares these two paths in `shared-file-gate.mjs` as read-from-a-clone by this repository, so moving or reshaping one fails in the pull request that does it rather than in this nightly the next morning. The two are independent — this one stands on its own, and that one only shortens the feedback loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ieKEMrEpR7hoZQcNMTuJr